### PR TITLE
Add Seungmee Lee to friends profiles list

### DIFF
--- a/app/friends/Friends.tsx
+++ b/app/friends/Friends.tsx
@@ -127,6 +127,12 @@ const profiles: Profile[] = [
     bio: "Illustrator working independently and with collective Trincea Ibiza. Shaky lines and questionable humor that can't be imitated by AI.",
     avatar: criminaliza.src,
   },
+  {
+    website: "seungmee-lee.com",
+    name: "Seungmee Lee",
+    bio: "A designer experimenting with pixels and codes.",
+    avatar: `https://www.google.com/s2/favicons?domain=seungmee-lee.com&sz=128`,
+  },
 ];
 
 interface PreviewModalProps {


### PR DESCRIPTION
## Summary
Added a new profile entry for Seungmee Lee to the friends profiles list in the Friends component.

## Changes
- Added new profile object for Seungmee Lee with the following details:
  - Website: seungmee-lee.com
  - Bio: "A designer experimenting with pixels and codes."
  - Avatar: Google favicon for the website domain

## Implementation Details
The new profile follows the existing pattern used by other entries in the profiles array. The avatar uses Google's favicon service to dynamically fetch the website's icon, which is consistent with how some other profiles in the list are configured.

https://claude.ai/code/session_01UNN7Ke16Ap74BVPz8o64jy