### PR TITLE
Fix solfege hands sprite hidden by Tailwind preflight

### DIFF
--- a/components/ExpandInline/SolfegeHands.module.css
+++ b/components/ExpandInline/SolfegeHands.module.css
@@ -14,6 +14,7 @@
 }
 
 .container img {
+  max-width: none;
   left: calc(var(--horizontal-offset) * -114.5px);
 }
 


### PR DESCRIPTION
Tailwind's base styles set `img { max-width: 100% }` which constrains
the 1370px sprite sheet to the 110px container, making it invisible.
Override with `max-width: none` so the sprite renders at full width.

https://claude.ai/code/session_01V5ZxSegKZ5gitoAtzM988G