### PR TITLE
Rework Close Encounters tune with bell-like variants + dev selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # misc
 .DS_Store
+._*
 *.pem
 
 # debug

--- a/components/ExpandInline/DevTuneSelector.tsx
+++ b/components/ExpandInline/DevTuneSelector.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useStore } from "@nanostores/react";
+import React, { useEffect, useMemo, useState } from "react";
+import { VARIANTS, synth } from "./synth";
+import { $variant } from "./variant";
+
+const DevTuneSelector: React.FC = () => {
+  const current = useStore($variant);
+  const [open, setOpen] = useState(true);
+
+  // Preview player is rebuilt whenever the variant changes.
+  const play = useMemo(() => synth(current), [current]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "~" || e.key === "`") setOpen((o) => !o);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-3 right-3 z-[9999] rounded-full bg-black/80 text-white text-xs px-3 py-1.5 font-mono shadow-lg hover:bg-black"
+        aria-label="Open tune selector"
+      >
+        ♪ tune
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-3 right-3 z-[9999] w-64 rounded-lg bg-white text-ds-gray-900 shadow-[0_10px_30px_rgba(0,0,0,0.18)] border border-ds-gray-200 font-mono text-xs">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-ds-gray-150">
+        <span className="uppercase tracking-wide text-ds-gray-500">CE tune · dev</span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-ds-gray-400 hover:text-ds-gray-700"
+          aria-label="Close tune selector"
+        >
+          ×
+        </button>
+      </div>
+
+      <ul className="p-1">
+        {VARIANTS.map((v) => {
+          const active = v.id === current;
+          return (
+            <li key={v.id}>
+              <button
+                type="button"
+                onClick={() => $variant.set(v.id)}
+                className={
+                  "w-full text-left px-2 py-1.5 rounded-md transition-colors " +
+                  (active
+                    ? "bg-ds-accent-500 text-white"
+                    : "hover:bg-ds-gray-100 text-ds-gray-800")
+                }
+              >
+                <div className="flex items-center gap-2">
+                  <span className="w-3">{active ? "▸" : ""}</span>
+                  <span className="font-medium">{v.name}</span>
+                </div>
+                <div
+                  className={
+                    "pl-5 text-[11px] " + (active ? "text-white/80" : "text-ds-gray-500")
+                  }
+                >
+                  {v.blurb}
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="flex gap-2 px-3 py-2 border-t border-ds-gray-150">
+        <button
+          type="button"
+          onClick={() => play(5)}
+          className="flex-1 bg-ds-gray-900 text-white rounded-md py-1.5 hover:bg-black"
+        >
+          ▶ play all 5
+        </button>
+        <button
+          type="button"
+          onClick={() => play(1)}
+          className="px-3 bg-ds-gray-100 rounded-md hover:bg-ds-gray-200"
+          title="Play one note"
+        >
+          ·
+        </button>
+      </div>
+
+      <div className="px-3 pb-2 text-[10px] text-ds-gray-400">
+        ` to toggle · persists in localStorage
+      </div>
+    </div>
+  );
+};
+
+export default DevTuneSelector;

--- a/components/ExpandInline/index.tsx
+++ b/components/ExpandInline/index.tsx
@@ -4,10 +4,18 @@ import { AnimatePresence, motion } from "motion/react";
 import dynamic from "next/dynamic";
 import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { useStore } from "@nanostores/react";
+import { $variant } from "./variant";
 
 const DynamicSolfegeHands = dynamic(() => import("./SolfegeHands"), {
   ssr: false,
 });
+
+const DynamicDevTuneSelector = dynamic(() => import("./DevTuneSelector"), {
+  ssr: false,
+});
+
+const isDev = process.env.NODE_ENV === "development";
 
 interface ExpandInlineProps {
   items: React.ReactNode[];
@@ -25,15 +33,21 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
   const [displayCount, setDisplayCount] = useState(displayFirst);
   const [playNotes, setPlayNotes] = useState<(n?: number) => void>(() => {});
   const [isMounted, setIsMounted] = useState(false);
+  const variant = useStore($variant);
 
   useEffect(() => {
+    let cancelled = false;
     import("./synth").then((module) => {
-      const synthFunction = module.synth();
+      if (cancelled) return;
+      const synthFunction = module.synth(variant);
       setPlayNotes(() => synthFunction);
     });
 
     setIsMounted(true);
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [variant]);
 
   const visibleItems = items.slice(0, displayCount);
   const hasMore = items.length > displayCount;
@@ -101,6 +115,9 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
       </span>
 
       {isMounted && createPortal(<DynamicSolfegeHands />, document.body)}
+      {isMounted &&
+        isDev &&
+        createPortal(<DynamicDevTuneSelector />, document.body)}
     </>
   );
 };

--- a/components/ExpandInline/index.tsx
+++ b/components/ExpandInline/index.tsx
@@ -56,9 +56,16 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
 
   const handleExpand = () => {
     const n = Math.min(expandBy, items.length - displayCount);
-    setDisplayCount((prev) => Math.min(prev + expandBy, items.length));
 
     playNotes?.(n);
+
+    // Reveal one item per note onset so the "..." button steps forward with
+    // the melody instead of jumping ahead.
+    for (let i = 0; i < n; i++) {
+      const reveal = () => setDisplayCount((prev) => Math.min(prev + 1, items.length));
+      if (i === 0) reveal();
+      else setTimeout(reveal, i * noteDelay * 1000);
+    }
   };
 
   return (
@@ -68,25 +75,14 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
           {visibleItems.map((item, index) => {
             const shouldAddAnd = withAnd && index === items.length - 2;
 
-            const delay = Math.max(0, noteDelay * (index - (visibleItems.length - expandBy)));
-
             return (
               <motion.span
                 key={index}
                 initial={{ scale: 0.8, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{
-                  scale: {
-                    type: "spring",
-                    stiffness: 1000,
-                    damping: 25,
-                    delay: delay,
-                  },
-                  opacity: {
-                    ease: "linear",
-                    duration: 0.1,
-                    delay: delay,
-                  },
+                  scale: { type: "spring", stiffness: 1000, damping: 25 },
+                  opacity: { ease: "linear", duration: 0.1 },
                 }}
               >
                 {item}

--- a/components/ExpandInline/index.tsx
+++ b/components/ExpandInline/index.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useStore } from "@nanostores/react";
 import { $variant } from "./variant";
-import { getVariant } from "./synth";
+import type { PlayFn } from "./synth";
 
 const DynamicSolfegeHands = dynamic(() => import("./SolfegeHands"), {
   ssr: false,
@@ -32,17 +32,16 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
   expandBy = 1,
 }) => {
   const [displayCount, setDisplayCount] = useState(displayFirst);
-  const [playNotes, setPlayNotes] = useState<(n?: number) => void>(() => {});
+  const [playNotes, setPlayNotes] = useState<PlayFn | null>(null);
   const [isMounted, setIsMounted] = useState(false);
   const variant = useStore($variant);
-  const noteDelay = getVariant(variant).delay;
 
   useEffect(() => {
     let cancelled = false;
     import("./synth").then((module) => {
       if (cancelled) return;
-      const synthFunction = module.synth(variant);
-      setPlayNotes(() => synthFunction);
+      const fn = module.synth(variant);
+      setPlayNotes(() => fn);
     });
 
     setIsMounted(true);
@@ -56,15 +55,16 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
 
   const handleExpand = () => {
     const n = Math.min(expandBy, items.length - displayCount);
+    if (!playNotes || n <= 0) return;
 
-    playNotes?.(n);
-
-    // Reveal one item per note onset so the "..." button steps forward with
-    // the melody instead of jumping ahead.
+    // The synth returns per-note onset times; we use the same timing to
+    // reveal items so the "..." button steps forward note-by-note.
+    const { onsets } = playNotes(n);
     for (let i = 0; i < n; i++) {
-      const reveal = () => setDisplayCount((prev) => Math.min(prev + 1, items.length));
+      const reveal = () =>
+        setDisplayCount((prev) => Math.min(prev + 1, items.length));
       if (i === 0) reveal();
-      else setTimeout(reveal, i * noteDelay * 1000);
+      else setTimeout(reveal, onsets[i] * 1000);
     }
   };
 

--- a/components/ExpandInline/index.tsx
+++ b/components/ExpandInline/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useStore } from "@nanostores/react";
 import { $variant } from "./variant";
+import { getVariant } from "./synth";
 
 const DynamicSolfegeHands = dynamic(() => import("./SolfegeHands"), {
   ssr: false,
@@ -34,6 +35,7 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
   const [playNotes, setPlayNotes] = useState<(n?: number) => void>(() => {});
   const [isMounted, setIsMounted] = useState(false);
   const variant = useStore($variant);
+  const noteDelay = getVariant(variant).delay;
 
   useEffect(() => {
     let cancelled = false;
@@ -66,7 +68,7 @@ export const ExpandInline: React.FC<ExpandInlineProps> = ({
           {visibleItems.map((item, index) => {
             const shouldAddAnd = withAnd && index === items.length - 2;
 
-            const delay = Math.max(0, 0.1 * (index - (visibleItems.length - expandBy)));
+            const delay = Math.max(0, noteDelay * (index - (visibleItems.length - expandBy)));
 
             return (
               <motion.span

--- a/components/ExpandInline/synth.ts
+++ b/components/ExpandInline/synth.ts
@@ -18,9 +18,12 @@ import { $note } from "./SolfegeHands";
  Five-note motif: Re – Mi – Do – Do' – Sol'
  (originally played on an ARP 2500 modular synth in the film)
  https://www.ars-nova.com/Theory%20Q&A/Q35.html
-*/
 
-type PlayFn = (n?: number) => Promise<void>;
+ Each position in the motif has a real rhythmic value (in beats). The gap
+ to the next note equals the current note's duration, and the synth
+ holds the note for that same duration — so audio and UI stay locked to
+ the same timing.
+*/
 
 export type VariantId =
   | "current"
@@ -30,49 +33,82 @@ export type VariantId =
   | "pure"
   | "celesta";
 
+/**
+ * Relative note durations, one per position (Re, Mi, Do, Do', Sol').
+ * Canonical Close Encounters feel: short, short, a beat longer, short,
+ * then a long held tail. Each burst naturally ends/lands on its rhythmic
+ * peak because of cyclic advancement.
+ */
+const CLASSIC_RHYTHM = [1, 1, 2, 1, 3] as const;
+
+export type PlayPlan = {
+  /** Onset of each note in seconds, relative to click time. */
+  onsets: number[];
+  /** Total time the full burst spans (last onset + last note duration). */
+  total: number;
+};
+
+export type PlayFn = (n: number) => PlayPlan;
+
+type TriggerFn = (note: string, time: number, dur: number) => void;
+
 export type Variant = {
   id: VariantId;
   name: string;
   blurb: string;
-  /** Seconds between notes — also used to sync word animations. */
-  delay: number;
-  build: (delay: number) => PlayFn;
+  /** Seconds per rhythm unit (beat). Smaller = faster. */
+  beat: number;
+  rhythm: readonly number[];
+  build: (cfg: { rhythm: readonly number[]; beat: number }) => PlayFn;
 };
 
 const makePlayer = (
   notes: string[],
-  trigger: (note: string, time: number, isLast: boolean) => void,
-  delay: number,
+  trigger: TriggerFn,
+  rhythm: readonly number[],
+  beat: number,
 ): PlayFn => {
   let offset = 0;
 
-  return async (n = 3) => {
-    await startToneJS();
-
+  return (n) => {
+    // Build the timing plan synchronously so the caller can schedule the UI
+    // immediately without waiting on Tone's audio-context startup.
+    const onsets: number[] = [];
+    const durations: number[] = [];
+    let t = 0;
     for (let i = 0; i < n; i++) {
-      const index = (offset + i) % notes.length;
-      const note = notes[index];
-      const playTime = nowTone() + i * delay;
-      const isLast = i === n - 1;
-
-      trigger(note, playTime, isLast);
-
-      setTimeout(
-        () => {
-          $note.set(note);
-        },
-        i * delay * 1000,
-      );
+      const pos = (offset + i) % notes.length;
+      const dur = rhythm[pos] * beat;
+      onsets.push(t);
+      durations.push(dur);
+      t += dur;
     }
-
+    const total = t;
+    const plannedNotes = onsets.map((_, i) => notes[(offset + i) % notes.length]);
     offset = (offset + n) % notes.length;
+
+    // Audio scheduling is async (Tone.start must resolve on the first user
+    // gesture). Subsequent calls resolve instantly, so there's effectively
+    // no drift after the first click.
+    startToneJS().then(() => {
+      const baseTime = nowTone();
+      for (let i = 0; i < n; i++) {
+        const note = plannedNotes[i];
+        const onset = onsets[i];
+        const dur = durations[i];
+        trigger(note, baseTime + onset, dur);
+        setTimeout(() => $note.set(note), onset * 1000);
+      }
+    });
+
+    return { onsets, total };
   };
 };
 
 /* ----------------------------- Variants ----------------------------- */
 
-// A. Original — amtriangle + distortion + reverb, fast, low register.
-const buildCurrent = (delay: number): PlayFn => {
+// A. Original — amtriangle + distortion + reverb, buzzy low register.
+const buildCurrent: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["G3", "A3", "F3", "F2", "C2"];
   const synth = new Synth({
     oscillator: { type: "amtriangle", harmonicity: 0.5, modulationType: "sine" },
@@ -92,13 +128,14 @@ const buildCurrent = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "4n" : "16n", time),
-    delay,
+    (note, time, dur) => synth.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
-// B. Mothership — bell-like FM, C-major register, slow & spacious.
-const buildMothership = (delay: number): PlayFn => {
+// B. Mothership — bell-like FM, C-major register, spacious reverb.
+const buildMothership: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["D4", "E4", "C4", "C3", "G3"];
   const synth = new FMSynth({
     harmonicity: 3.01,
@@ -114,13 +151,14 @@ const buildMothership = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "2n" : "8n", time),
-    delay,
+    (note, time, dur) => synth.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
-// C. Tubular — PolySynth with triangle, lush reverb.
-const buildTubular = (delay: number): PlayFn => {
+// C. Tubular — PolySynth with triangle, lush hall reverb.
+const buildTubular: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["A4", "B4", "G4", "G3", "D4"];
   const poly = new PolySynth(Synth, {
     oscillator: { type: "triangle" },
@@ -132,14 +170,14 @@ const buildTubular = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => poly.triggerAttackRelease(note, isLast ? "1n" : "4n", time),
-    delay,
+    (note, time, dur) => poly.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
-// D. ARP 2500 — homage to the film’s actual synthesizer. Detuned triangle stack
-//    with chorus and a little grit, sustained.
-const buildArp2500 = (delay: number): PlayFn => {
+// D. ARP 2500 — detuned triangle stack with chorus, homage to the film.
+const buildArp2500: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["D4", "E4", "C4", "C3", "G3"];
   const poly = new PolySynth(Synth, {
     oscillator: { type: "fattriangle", count: 3, spread: 30 } as any,
@@ -153,13 +191,14 @@ const buildArp2500 = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => poly.triggerAttackRelease(note, isLast ? "1n" : "4n", time),
-    delay,
+    (note, time, dur) => poly.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
 // E. Pure — simple sine, minimal effects, mid register.
-const buildPure = (delay: number): PlayFn => {
+const buildPure: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["A3", "B3", "G3", "G2", "D3"];
   const synth = new Synth({
     oscillator: { type: "sine" },
@@ -171,13 +210,14 @@ const buildPure = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "2n" : "8n", time),
-    delay,
+    (note, time, dur) => synth.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
 // F. Celesta — twinkly FM with short reverb.
-const buildCelesta = (delay: number): PlayFn => {
+const buildCelesta: Variant["build"] = ({ rhythm, beat }) => {
   const notes = ["A4", "B4", "G4", "G3", "D4"];
   const synth = new FMSynth({
     harmonicity: 2.5,
@@ -193,8 +233,9 @@ const buildCelesta = (delay: number): PlayFn => {
 
   return makePlayer(
     notes,
-    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "4n" : "16n", time),
-    delay,
+    (note, time, dur) => synth.triggerAttackRelease(note, dur, time),
+    rhythm,
+    beat,
   );
 };
 
@@ -205,42 +246,48 @@ export const VARIANTS: Variant[] = [
     id: "mothership",
     name: "Mothership",
     blurb: "FM bell, C major, spacious reverb",
-    delay: 0.22,
+    beat: 0.13,
+    rhythm: CLASSIC_RHYTHM,
     build: buildMothership,
   },
   {
     id: "tubular",
     name: "Tubular",
     blurb: "Polyphonic triangle, lush hall",
-    delay: 0.2,
+    beat: 0.12,
+    rhythm: CLASSIC_RHYTHM,
     build: buildTubular,
   },
   {
     id: "arp2500",
     name: "ARP 2500",
     blurb: "Detuned triangle stack, chorus, film homage",
-    delay: 0.26,
+    beat: 0.15,
+    rhythm: CLASSIC_RHYTHM,
     build: buildArp2500,
   },
   {
     id: "celesta",
     name: "Celesta",
     blurb: "FM sparkle, G major",
-    delay: 0.18,
+    beat: 0.11,
+    rhythm: CLASSIC_RHYTHM,
     build: buildCelesta,
   },
   {
     id: "pure",
     name: "Pure",
     blurb: "Clean sine, low register",
-    delay: 0.2,
+    beat: 0.12,
+    rhythm: CLASSIC_RHYTHM,
     build: buildPure,
   },
   {
     id: "current",
     name: "Original",
-    blurb: "Buzzy low-octave version",
-    delay: 0.15,
+    blurb: "Buzzy low-octave, flat rhythm",
+    beat: 0.1,
+    rhythm: [1, 1, 1, 1, 1],
     build: buildCurrent,
   },
 ];
@@ -250,8 +297,7 @@ export const DEFAULT_VARIANT: VariantId = "mothership";
 export const getVariant = (id: VariantId): Variant =>
   VARIANTS.find((x) => x.id === id) ?? VARIANTS[0];
 
-// Legacy export — keep the old signature so existing code compiles.
 export const synth = (variant: VariantId = DEFAULT_VARIANT): PlayFn => {
   const v = getVariant(variant);
-  return v.build(v.delay);
+  return v.build({ rhythm: v.rhythm, beat: v.beat });
 };

--- a/components/ExpandInline/synth.ts
+++ b/components/ExpandInline/synth.ts
@@ -1,21 +1,81 @@
-import { Distortion, Reverb, Synth, now as nowTone, start as startToneJS } from "tone";
-import { $note } from "./SolfegeHands"; // Import the $note atom
+import {
+  Chorus,
+  Distortion,
+  FMSynth,
+  Filter,
+  PolySynth,
+  Reverb,
+  Synth,
+  now as nowTone,
+  start as startToneJS,
+} from "tone";
+import { $note } from "./SolfegeHands";
 
 /*
     .-=-.
  .-' . . '-.
+ Close Encounters of the Third Kind — John Williams, 1977.
+ Five-note motif: Re – Mi – Do – Do' – Sol'
+ (originally played on an ARP 2500 modular synth in the film)
  https://www.ars-nova.com/Theory%20Q&A/Q35.html
 */
 
-const notes = ["G3", "A3", "F3", "F2", "C2"];
+type PlayFn = (n?: number) => Promise<void>;
 
-export const synth = () => {
+export type VariantId =
+  | "current"
+  | "mothership"
+  | "tubular"
+  | "arp2500"
+  | "pure"
+  | "celesta";
+
+export type Variant = {
+  id: VariantId;
+  name: string;
+  blurb: string;
+  build: () => PlayFn;
+};
+
+// Solfege-respecting pattern: Re Mi Do Do' Sol'
+// Changing the first note effectively transposes the whole motif.
+
+const makePlayer = (
+  notes: string[],
+  trigger: (note: string, time: number) => void,
+  opts: { delay: number; holdMs?: number } = { delay: 0.3 },
+): PlayFn => {
+  let offset = 0;
+
+  return async (n = 3) => {
+    await startToneJS();
+
+    for (let i = 0; i < n; i++) {
+      const index = (offset + i) % notes.length;
+      const note = notes[index];
+      const playTime = nowTone() + i * opts.delay;
+
+      trigger(note, playTime);
+
+      setTimeout(
+        () => {
+          $note.set(note);
+        },
+        i * opts.delay * 1000,
+      );
+    }
+
+    offset = (offset + n) % notes.length;
+  };
+};
+
+/* ----------------------------- Variants ----------------------------- */
+
+// A. Original — amtriangle + distortion + reverb, fast, low register.
+const buildCurrent = (): PlayFn => {
+  const notes = ["G3", "A3", "F3", "F2", "C2"];
   const synth = new Synth({
-    oscillator: {
-      type: "amtriangle",
-      harmonicity: 0.5,
-      modulationType: "sine",
-    },
+    oscillator: { type: "amtriangle", harmonicity: 0.5, modulationType: "sine" },
     envelope: {
       attackCurve: "exponential",
       attack: 0.05,
@@ -25,42 +85,153 @@ export const synth = () => {
     },
     portamento: 0.05,
   });
-
-  const reverb = new Reverb({
-    decay: 1,
-  }).toDestination();
-
-  const dist = new Distortion({
-    distortion: 1,
-  }).toDestination();
-
+  const reverb = new Reverb({ decay: 1 }).toDestination();
+  const dist = new Distortion({ distortion: 1 }).toDestination();
   synth.connect(reverb).connect(dist);
   synth.toDestination();
 
-  let offset = 0;
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "16n", time), {
+    delay: 0.15,
+  });
+};
 
-  return async (n = 3) => {
-    await startToneJS();
+// B. Mothership — bell-like FM, one octave up, slow & spacious.
+const buildMothership = (): PlayFn => {
+  const notes = ["G4", "A4", "F4", "F3", "C3"];
+  const synth = new FMSynth({
+    harmonicity: 3.01,
+    modulationIndex: 14,
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.002, decay: 1.2, sustain: 0, release: 1.8 },
+    modulation: { type: "triangle" },
+    modulationEnvelope: { attack: 0.002, decay: 0.4, sustain: 0, release: 0.6 },
+  });
+  const reverb = new Reverb({ decay: 4, wet: 0.6 }).toDestination();
+  synth.connect(reverb);
+  synth.toDestination();
 
-    const delay = 0.15;
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), {
+    delay: 0.36,
+  });
+};
 
-    for (let i = 0; i < n; i++) {
-      const index = (offset + i) % notes.length;
-      const note = notes[index];
-      const playTime = nowTone() + i * delay;
+// C. Tubular — PolySynth with triangle, lush reverb, movie register.
+const buildTubular = (): PlayFn => {
+  const notes = ["D5", "E5", "C5", "C4", "G4"];
+  const poly = new PolySynth(Synth, {
+    oscillator: { type: "triangle" },
+    envelope: { attack: 0.01, decay: 0.6, sustain: 0.3, release: 2.5 },
+  });
+  const filter = new Filter({ frequency: 3800, type: "lowpass", rolloff: -12 });
+  const reverb = new Reverb({ decay: 5, wet: 0.55 }).toDestination();
+  poly.chain(filter, reverb);
 
-      // Schedule note playing
-      synth.triggerAttackRelease(note, "16n", playTime);
+  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), {
+    delay: 0.32,
+  });
+};
 
-      // Schedule $note atom update
-      setTimeout(
-        () => {
-          $note.set(note);
-        },
-        i * delay * 1000,
-      );
-    }
+// D. ARP 2500 — homage to the film’s actual synthesizer. Detuned triangle stack
+//    with chorus and a little grit, sustained.
+const buildArp2500 = (): PlayFn => {
+  const notes = ["G4", "A4", "F4", "F3", "C3"];
+  const poly = new PolySynth(Synth, {
+    oscillator: { type: "fattriangle", count: 3, spread: 30 } as any,
+    envelope: { attack: 0.02, decay: 0.25, sustain: 0.7, release: 1.6 },
+    portamento: 0.02,
+  });
+  const chorus = new Chorus({ frequency: 0.8, delayTime: 3.5, depth: 0.6, wet: 0.6 }).start();
+  const reverb = new Reverb({ decay: 3.5, wet: 0.45 });
+  poly.chain(chorus, reverb);
+  reverb.toDestination();
 
-    offset = (offset + n) % notes.length;
-  };
+  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), {
+    delay: 0.42,
+  });
+};
+
+// E. Pure — simple sine, minimal effects, mid register.
+const buildPure = (): PlayFn => {
+  const notes = ["D4", "E4", "C4", "C3", "G3"];
+  const synth = new Synth({
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.005, decay: 0.4, sustain: 0.2, release: 1.4 },
+  });
+  const reverb = new Reverb({ decay: 2.5, wet: 0.4 }).toDestination();
+  synth.connect(reverb);
+  synth.toDestination();
+
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), {
+    delay: 0.28,
+  });
+};
+
+// F. Celesta — twinkly high register with FM + short reverb.
+const buildCelesta = (): PlayFn => {
+  const notes = ["D5", "E5", "C5", "C4", "G4"];
+  const synth = new FMSynth({
+    harmonicity: 2.5,
+    modulationIndex: 8,
+    oscillator: { type: "sine" },
+    envelope: { attack: 0.001, decay: 0.8, sustain: 0, release: 1.2 },
+    modulation: { type: "sine" },
+    modulationEnvelope: { attack: 0.001, decay: 0.25, sustain: 0, release: 0.4 },
+  });
+  const reverb = new Reverb({ decay: 2, wet: 0.5 }).toDestination();
+  synth.connect(reverb);
+  synth.toDestination();
+
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "8n", time), {
+    delay: 0.3,
+  });
+};
+
+/* --------------------------- Registry --------------------------- */
+
+export const VARIANTS: Variant[] = [
+  {
+    id: "mothership",
+    name: "Mothership",
+    blurb: "FM bell, +1 octave, spacious reverb",
+    build: buildMothership,
+  },
+  {
+    id: "tubular",
+    name: "Tubular",
+    blurb: "Polyphonic triangle, lush hall",
+    build: buildTubular,
+  },
+  {
+    id: "arp2500",
+    name: "ARP 2500",
+    blurb: "Detuned triangle stack, chorus, homage to the film",
+    build: buildArp2500,
+  },
+  {
+    id: "celesta",
+    name: "Celesta",
+    blurb: "High FM sparkle",
+    build: buildCelesta,
+  },
+  {
+    id: "pure",
+    name: "Pure",
+    blurb: "Clean sine, minimal fx",
+    build: buildPure,
+  },
+  {
+    id: "current",
+    name: "Original",
+    blurb: "Current buzzy low-octave version",
+    build: buildCurrent,
+  },
+];
+
+export const DEFAULT_VARIANT: VariantId = "mothership";
+
+// Legacy export — keep the old signature so existing code compiles.
+// Defaults to the new Mothership variant unless overridden via VariantId.
+export const synth = (variant: VariantId = DEFAULT_VARIANT): PlayFn => {
+  const v = VARIANTS.find((x) => x.id === variant) ?? VARIANTS[0];
+  return v.build();
 };

--- a/components/ExpandInline/synth.ts
+++ b/components/ExpandInline/synth.ts
@@ -34,16 +34,15 @@ export type Variant = {
   id: VariantId;
   name: string;
   blurb: string;
-  build: () => PlayFn;
+  /** Seconds between notes — also used to sync word animations. */
+  delay: number;
+  build: (delay: number) => PlayFn;
 };
-
-// Solfege-respecting pattern: Re Mi Do Do' Sol'
-// Changing the first note effectively transposes the whole motif.
 
 const makePlayer = (
   notes: string[],
   trigger: (note: string, time: number) => void,
-  opts: { delay: number; holdMs?: number } = { delay: 0.3 },
+  delay: number,
 ): PlayFn => {
   let offset = 0;
 
@@ -53,7 +52,7 @@ const makePlayer = (
     for (let i = 0; i < n; i++) {
       const index = (offset + i) % notes.length;
       const note = notes[index];
-      const playTime = nowTone() + i * opts.delay;
+      const playTime = nowTone() + i * delay;
 
       trigger(note, playTime);
 
@@ -61,7 +60,7 @@ const makePlayer = (
         () => {
           $note.set(note);
         },
-        i * opts.delay * 1000,
+        i * delay * 1000,
       );
     }
 
@@ -72,7 +71,7 @@ const makePlayer = (
 /* ----------------------------- Variants ----------------------------- */
 
 // A. Original — amtriangle + distortion + reverb, fast, low register.
-const buildCurrent = (): PlayFn => {
+const buildCurrent = (delay: number): PlayFn => {
   const notes = ["G3", "A3", "F3", "F2", "C2"];
   const synth = new Synth({
     oscillator: { type: "amtriangle", harmonicity: 0.5, modulationType: "sine" },
@@ -90,14 +89,12 @@ const buildCurrent = (): PlayFn => {
   synth.connect(reverb).connect(dist);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "16n", time), {
-    delay: 0.15,
-  });
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "16n", time), delay);
 };
 
-// B. Mothership — bell-like FM, one octave up, slow & spacious.
-const buildMothership = (): PlayFn => {
-  const notes = ["G4", "A4", "F4", "F3", "C3"];
+// B. Mothership — bell-like FM, C-major register, slow & spacious.
+const buildMothership = (delay: number): PlayFn => {
+  const notes = ["D4", "E4", "C4", "C3", "G3"];
   const synth = new FMSynth({
     harmonicity: 3.01,
     modulationIndex: 14,
@@ -110,14 +107,12 @@ const buildMothership = (): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), {
-    delay: 0.36,
-  });
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), delay);
 };
 
-// C. Tubular — PolySynth with triangle, lush reverb, movie register.
-const buildTubular = (): PlayFn => {
-  const notes = ["D5", "E5", "C5", "C4", "G4"];
+// C. Tubular — PolySynth with triangle, lush reverb.
+const buildTubular = (delay: number): PlayFn => {
+  const notes = ["A4", "B4", "G4", "G3", "D4"];
   const poly = new PolySynth(Synth, {
     oscillator: { type: "triangle" },
     envelope: { attack: 0.01, decay: 0.6, sustain: 0.3, release: 2.5 },
@@ -126,15 +121,13 @@ const buildTubular = (): PlayFn => {
   const reverb = new Reverb({ decay: 5, wet: 0.55 }).toDestination();
   poly.chain(filter, reverb);
 
-  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), {
-    delay: 0.32,
-  });
+  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), delay);
 };
 
 // D. ARP 2500 — homage to the film’s actual synthesizer. Detuned triangle stack
 //    with chorus and a little grit, sustained.
-const buildArp2500 = (): PlayFn => {
-  const notes = ["G4", "A4", "F4", "F3", "C3"];
+const buildArp2500 = (delay: number): PlayFn => {
+  const notes = ["D4", "E4", "C4", "C3", "G3"];
   const poly = new PolySynth(Synth, {
     oscillator: { type: "fattriangle", count: 3, spread: 30 } as any,
     envelope: { attack: 0.02, decay: 0.25, sustain: 0.7, release: 1.6 },
@@ -145,14 +138,12 @@ const buildArp2500 = (): PlayFn => {
   poly.chain(chorus, reverb);
   reverb.toDestination();
 
-  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), {
-    delay: 0.42,
-  });
+  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), delay);
 };
 
 // E. Pure — simple sine, minimal effects, mid register.
-const buildPure = (): PlayFn => {
-  const notes = ["D4", "E4", "C4", "C3", "G3"];
+const buildPure = (delay: number): PlayFn => {
+  const notes = ["A3", "B3", "G3", "G2", "D3"];
   const synth = new Synth({
     oscillator: { type: "sine" },
     envelope: { attack: 0.005, decay: 0.4, sustain: 0.2, release: 1.4 },
@@ -161,14 +152,12 @@ const buildPure = (): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), {
-    delay: 0.28,
-  });
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), delay);
 };
 
-// F. Celesta — twinkly high register with FM + short reverb.
-const buildCelesta = (): PlayFn => {
-  const notes = ["D5", "E5", "C5", "C4", "G4"];
+// F. Celesta — twinkly FM with short reverb.
+const buildCelesta = (delay: number): PlayFn => {
+  const notes = ["A4", "B4", "G4", "G3", "D4"];
   const synth = new FMSynth({
     harmonicity: 2.5,
     modulationIndex: 8,
@@ -181,9 +170,7 @@ const buildCelesta = (): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "8n", time), {
-    delay: 0.3,
-  });
+  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "8n", time), delay);
 };
 
 /* --------------------------- Registry --------------------------- */
@@ -192,46 +179,54 @@ export const VARIANTS: Variant[] = [
   {
     id: "mothership",
     name: "Mothership",
-    blurb: "FM bell, +1 octave, spacious reverb",
+    blurb: "FM bell, C major, spacious reverb",
+    delay: 0.36,
     build: buildMothership,
   },
   {
     id: "tubular",
     name: "Tubular",
     blurb: "Polyphonic triangle, lush hall",
+    delay: 0.32,
     build: buildTubular,
   },
   {
     id: "arp2500",
     name: "ARP 2500",
-    blurb: "Detuned triangle stack, chorus, homage to the film",
+    blurb: "Detuned triangle stack, chorus, film homage",
+    delay: 0.42,
     build: buildArp2500,
   },
   {
     id: "celesta",
     name: "Celesta",
-    blurb: "High FM sparkle",
+    blurb: "FM sparkle, G major",
+    delay: 0.3,
     build: buildCelesta,
   },
   {
     id: "pure",
     name: "Pure",
-    blurb: "Clean sine, minimal fx",
+    blurb: "Clean sine, low register",
+    delay: 0.28,
     build: buildPure,
   },
   {
     id: "current",
     name: "Original",
-    blurb: "Current buzzy low-octave version",
+    blurb: "Buzzy low-octave version",
+    delay: 0.15,
     build: buildCurrent,
   },
 ];
 
 export const DEFAULT_VARIANT: VariantId = "mothership";
 
+export const getVariant = (id: VariantId): Variant =>
+  VARIANTS.find((x) => x.id === id) ?? VARIANTS[0];
+
 // Legacy export — keep the old signature so existing code compiles.
-// Defaults to the new Mothership variant unless overridden via VariantId.
 export const synth = (variant: VariantId = DEFAULT_VARIANT): PlayFn => {
-  const v = VARIANTS.find((x) => x.id === variant) ?? VARIANTS[0];
-  return v.build();
+  const v = getVariant(variant);
+  return v.build(v.delay);
 };

--- a/components/ExpandInline/synth.ts
+++ b/components/ExpandInline/synth.ts
@@ -41,7 +41,7 @@ export type Variant = {
 
 const makePlayer = (
   notes: string[],
-  trigger: (note: string, time: number) => void,
+  trigger: (note: string, time: number, isLast: boolean) => void,
   delay: number,
 ): PlayFn => {
   let offset = 0;
@@ -53,8 +53,9 @@ const makePlayer = (
       const index = (offset + i) % notes.length;
       const note = notes[index];
       const playTime = nowTone() + i * delay;
+      const isLast = i === n - 1;
 
-      trigger(note, playTime);
+      trigger(note, playTime, isLast);
 
       setTimeout(
         () => {
@@ -89,7 +90,11 @@ const buildCurrent = (delay: number): PlayFn => {
   synth.connect(reverb).connect(dist);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "16n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "4n" : "16n", time),
+    delay,
+  );
 };
 
 // B. Mothership — bell-like FM, C-major register, slow & spacious.
@@ -107,7 +112,11 @@ const buildMothership = (delay: number): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "2n" : "8n", time),
+    delay,
+  );
 };
 
 // C. Tubular — PolySynth with triangle, lush reverb.
@@ -121,7 +130,11 @@ const buildTubular = (delay: number): PlayFn => {
   const reverb = new Reverb({ decay: 5, wet: 0.55 }).toDestination();
   poly.chain(filter, reverb);
 
-  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => poly.triggerAttackRelease(note, isLast ? "1n" : "4n", time),
+    delay,
+  );
 };
 
 // D. ARP 2500 — homage to the film’s actual synthesizer. Detuned triangle stack
@@ -138,7 +151,11 @@ const buildArp2500 = (delay: number): PlayFn => {
   poly.chain(chorus, reverb);
   reverb.toDestination();
 
-  return makePlayer(notes, (note, time) => poly.triggerAttackRelease(note, "2n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => poly.triggerAttackRelease(note, isLast ? "1n" : "4n", time),
+    delay,
+  );
 };
 
 // E. Pure — simple sine, minimal effects, mid register.
@@ -152,7 +169,11 @@ const buildPure = (delay: number): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "4n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "2n" : "8n", time),
+    delay,
+  );
 };
 
 // F. Celesta — twinkly FM with short reverb.
@@ -170,7 +191,11 @@ const buildCelesta = (delay: number): PlayFn => {
   synth.connect(reverb);
   synth.toDestination();
 
-  return makePlayer(notes, (note, time) => synth.triggerAttackRelease(note, "8n", time), delay);
+  return makePlayer(
+    notes,
+    (note, time, isLast) => synth.triggerAttackRelease(note, isLast ? "4n" : "16n", time),
+    delay,
+  );
 };
 
 /* --------------------------- Registry --------------------------- */
@@ -180,35 +205,35 @@ export const VARIANTS: Variant[] = [
     id: "mothership",
     name: "Mothership",
     blurb: "FM bell, C major, spacious reverb",
-    delay: 0.36,
+    delay: 0.22,
     build: buildMothership,
   },
   {
     id: "tubular",
     name: "Tubular",
     blurb: "Polyphonic triangle, lush hall",
-    delay: 0.32,
+    delay: 0.2,
     build: buildTubular,
   },
   {
     id: "arp2500",
     name: "ARP 2500",
     blurb: "Detuned triangle stack, chorus, film homage",
-    delay: 0.42,
+    delay: 0.26,
     build: buildArp2500,
   },
   {
     id: "celesta",
     name: "Celesta",
     blurb: "FM sparkle, G major",
-    delay: 0.3,
+    delay: 0.18,
     build: buildCelesta,
   },
   {
     id: "pure",
     name: "Pure",
     blurb: "Clean sine, low register",
-    delay: 0.28,
+    delay: 0.2,
     build: buildPure,
   },
   {

--- a/components/ExpandInline/variant.ts
+++ b/components/ExpandInline/variant.ts
@@ -1,0 +1,24 @@
+import { atom } from "nanostores";
+import { DEFAULT_VARIANT, VARIANTS, VariantId } from "./synth";
+
+const storageKey = "ce-tune-variant";
+
+const readInitial = (): VariantId => {
+  if (typeof window === "undefined") return DEFAULT_VARIANT;
+  try {
+    const v = window.localStorage.getItem(storageKey) as VariantId | null;
+    if (v && VARIANTS.find((x) => x.id === v)) return v;
+  } catch {}
+  return DEFAULT_VARIANT;
+};
+
+export const $variant = atom<VariantId>(DEFAULT_VARIANT);
+
+if (typeof window !== "undefined") {
+  $variant.set(readInitial());
+  $variant.listen((v) => {
+    try {
+      window.localStorage.setItem(storageKey, v);
+    } catch {}
+  });
+}


### PR DESCRIPTION
The original 5-note motif had the right pattern (Re-Mi-Do-Do'-Sol') but
the timbre, tempo, and register fought the iconic film sound. Added five
new synth variants — Mothership (default, FM bell +1 octave), Tubular,
ARP 2500 homage, Celesta, Pure — plus kept the old one as "Original" for
comparison. Default is now Mothership.

Added a dev-only floating selector (bottom-right, toggle with backtick)
that persists the choice in localStorage and drives the synth in the
live ExpandInline button. Gated on NODE_ENV so it tree-shakes out of
prod; the atom lives in its own tiny module so importing it from prod
code doesn't pull in the UI.