### PR TITLE
Refine homepage bio and professional narrative

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,11 +35,12 @@ export default function Page() {
         <div className="text-ds-gray-800 text-base/relaxed md:text-ds-base/relaxed mb-14 md:mb-16">
           <div className="[&_p]:my-5">
             <p>
-              I&apos;m a design-minded engineer and founder based in Copenhagen. I care about
-              systems that scale, tools that stay simple, and UIs that feel good.
+              Designer-engineer and founder based in Copenhagen. I&apos;m obsessed with craft
+              &mdash; systems that scale gracefully, tools that stay out of the way, and
+              interfaces that feel alive.
             </p>
             <p>
-              For over 15 years I&apos;ve been writing code professionally. I maintain{" "}
+              Shipping code for 15+ years. I maintain{" "}
               <Showcase
                 media={{ image: "/screenshot/github", aspectRatio: 1400 / 860 }}
                 prefer="below"
@@ -59,7 +60,7 @@ export default function Page() {
                   conference talks
                 </Link>
               </Showcase>
-              , and have spent years leading engineering teams. Tools I use:{" "}
+              , and have led engineering teams from scrappy to grown-up. Stack of choice:{" "}
               <ExpandInline
                 items={[
                   "React",
@@ -85,20 +86,20 @@ export default function Page() {
               />
             </p>
             <p>
-              Previously, I co-founded{" "}
+              I co-founded{" "}
               <Showcase media={{ video: resumeBuilderVideo, aspectRatio: 1200 / 768 }}>
                 <Link className="solid-link" href="https://resume.io">
                   resume.io
                 </Link>
               </Showcase>{" "}
-              and led it through scaling and acquisition. More recently, co-founded{" "}
+              and steered it from zero to acquisition. More recently,{" "}
               <Showcase media={{ image: "/screenshot/fira", aspectRatio: 1400 / 860 }}>
                 <Link href="https://firaresearch.com" className="solid-link">
                   Fira (YC W25)
                 </Link>
               </Showcase>
-              , an agentic AI analyst for financial research. Now I&apos;m exploring collaborative
-              software and agentic tooling and building something new.
+              {" "}&mdash; an agentic AI analyst for financial research. Currently heads-down on
+              something new at the intersection of collaborative software and agents.
               {/* TODO: add back interactive storytelling with new preview
               , and{" "}
               <Showcase media={{ video: domikLtdVideo, aspectRatio: 1460 / 1080 }}>
@@ -109,8 +110,8 @@ export default function Page() {
               */}
             </p>
             <p>
-              Principles: I believe constraints unlock creativity. Interactivity and collaboration
-              over static. Tools should be simple and minimal.
+              A few beliefs: constraints are a gift. Interactive beats static. The best tools are
+              invisible.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Updated the homepage bio section to present a more refined and authentic professional narrative. The changes emphasize craft, practical experience, and current focus areas while maintaining the same overall structure and information.

## Key Changes
- **Opening statement**: Simplified and reframed from "design-minded engineer" to "Designer-engineer" with emphasis on craft obsession
- **Professional experience**: Condensed "For over 15 years I've been writing code professionally" to "Shipping code for 15+ years" for punchier delivery
- **Tools/Stack language**: Changed "Tools I use" to "Stack of choice" for more contemporary phrasing
- **Leadership experience**: Reworded from generic "spent years leading engineering teams" to more specific "led engineering teams from scrappy to grown-up"
- **Company descriptions**: 
  - resume.io: Changed from "led it through scaling and acquisition" to "steered it from zero to acquisition"
  - Fira: Reformatted with em-dash and refined description of current work focus
- **Principles section**: Condensed three principles into more concise, impactful statements ("constraints are a gift", "Interactive beats static", "The best tools are invisible")

## Implementation Details
- Maintained all existing links and component structure (Showcase, ExpandInline, Link components)
- Preserved HTML entities (e.g., `&mdash;`) for proper typography
- No changes to styling, layout, or component logic
- All content updates are text-only refinements to the bio narrative

https://claude.ai/code/session_0118PAZrBnH4ejeufx3ZWtbH